### PR TITLE
Fix missing TLS attribute when clone EmailConfig

### DIFF
--- a/pkg/notify/notifier/email/email.go
+++ b/pkg/notify/notifier/email/email.go
@@ -244,6 +244,7 @@ func (n *Notifier) clone(ec *nmconfig.EmailConfig) *nmconfig.EmailConfig {
 		AuthPassword: ec.AuthPassword,
 		AuthSecret:   ec.AuthSecret,
 		RequireTLS:   ec.RequireTLS,
+		TLS:          ec.TLS,
 	}
 }
 
@@ -321,8 +322,7 @@ func (n *Notifier) getEmailConfig(e *nmconfig.Email) (*config.EmailConfig, error
 		}
 
 		ec.TLSConfig = tlsConfig
-		requireTLS := true
-		ec.RequireTLS = &requireTLS
+		ec.RequireTLS = &e.EmailConfig.RequireTLS
 	}
 
 	return ec, nil

--- a/pkg/notify/notifier/email/email.go
+++ b/pkg/notify/notifier/email/email.go
@@ -322,7 +322,6 @@ func (n *Notifier) getEmailConfig(e *nmconfig.Email) (*config.EmailConfig, error
 		}
 
 		ec.TLSConfig = tlsConfig
-		ec.RequireTLS = &e.EmailConfig.RequireTLS
 	}
 
 	return ec, nil


### PR DESCRIPTION
Allow notification manager send email to SMTP SSL Email Server
port 465 TCP