### PR TITLE
support markdown message type and @someone

### DIFF
--- a/helm/templates/template.yaml
+++ b/helm/templates/template.yaml
@@ -22,6 +22,27 @@ data:
     {{ "{{- end }}" }}
     {{ "{{- end }}" }}
 
+    {{ "{{ define \"nm.markdown.subject\" }}{{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }} {{ .Name }}={{ .Value }} {{ end }}" }}
+    {{ "{{- end }}" }}
+
+    {{ "{{ define \"__nm_alert_list_markdown\" }}{{ range . }}### Labels:" }}
+    {{ "{{ range .Labels.SortedPairs }}{{ if ne .Name \"runbook_url\" }}- {{ .Name }} = {{ .Value }}{{ end }}" }}
+    {{ "{{ end }}### Annotations:" }}
+    {{ "{{ range .Annotations.SortedPairs }}{{ if ne .Name \"runbook_url\"}}- {{ .Name }} = {{ .Value }}{{ end }}" }}
+    {{ "{{ end }}" }}
+    {{ "{{ end }}{{ end }}" }}
+
+    {{ "{{ define \"nm.default.markdown\" }}{{ template \"nm.markdown.subject\" . }}" }}
+    {{ "{{ if gt (len .Alerts.Firing) 0 -}}" }}
+    {{ "## <font color=#CD0000>Alerts Firing:</font>" }}
+    {{ "{{ template \"__nm_alert_list_markdown\" .Alerts.Firing }}" }}
+    {{ "{{- end }}" }}
+    {{ "{{ if gt (len .Alerts.Resolved) 0 -}}" }}
+    {{ "## <font color=#00CD00>Alerts Resolved:</font>" }}
+    {{ "{{ template \"__nm_alert_list_markdown\" .Alerts.Resolved }}" }}
+    {{ "{{- end }}" }}
+    {{ "{{- end }}" }}
+
     {{ "{{ define \"nm.default.html\" }}" }}
     {{ "  <html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns=\"http://www.w3.org/1999/xhtml\" style=\"font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;\">" }}
     {{ "  <head style=\"font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;\">" }}

--- a/pkg/apis/v2beta2/notificationmanager_types.go
+++ b/pkg/apis/v2beta2/notificationmanager_types.go
@@ -19,7 +19,7 @@ package v2beta2
 import (
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -188,6 +188,8 @@ type DingTalkOptions struct {
 	// The name of the template to generate DingTalk message.
 	// If the global template is not set, it will use default.
 	Template string `json:"template,omitempty"`
+	// template type: text or markdown, default type is text
+	TmplType string `json:"tmplType,omitempty"`
 	// The time of token expired.
 	TokenExpires time.Duration `json:"tokenExpires,omitempty"`
 	// The maximum message size that can be sent to conversation in a request.

--- a/pkg/apis/v2beta2/notificationmanager_types.go
+++ b/pkg/apis/v2beta2/notificationmanager_types.go
@@ -188,6 +188,8 @@ type DingTalkOptions struct {
 	// The name of the template to generate DingTalk message.
 	// If the global template is not set, it will use default.
 	Template string `json:"template,omitempty"`
+	// message type: text or markdown
+	MsgType string `json:"msgType,omitempty"`
 	// The time of token expired.
 	TokenExpires time.Duration `json:"tokenExpires,omitempty"`
 	// The maximum message size that can be sent to conversation in a request.

--- a/pkg/apis/v2beta2/notificationmanager_types.go
+++ b/pkg/apis/v2beta2/notificationmanager_types.go
@@ -188,8 +188,6 @@ type DingTalkOptions struct {
 	// The name of the template to generate DingTalk message.
 	// If the global template is not set, it will use default.
 	Template string `json:"template,omitempty"`
-	// message type: text or markdown
-	MsgType string `json:"msgType,omitempty"`
 	// The time of token expired.
 	TokenExpires time.Duration `json:"tokenExpires,omitempty"`
 	// The maximum message size that can be sent to conversation in a request.

--- a/pkg/apis/v2beta2/receiver_types.go
+++ b/pkg/apis/v2beta2/receiver_types.go
@@ -48,8 +48,8 @@ type DingTalkReceiver struct {
 	ChatBot *DingTalkChatBot `json:"chatbot,omitempty"`
 	// The conversation which message will send to.
 	Conversation *DingTalkConversation `json:"conversation,omitempty"`
-	// message type: text or markdown
-	MsgType *string `json:"msgType,omitempty"`
+	// template type: text or markdown
+	TmplType *string `json:"tmplType,omitempty"`
 }
 
 type EmailReceiver struct {

--- a/pkg/apis/v2beta2/receiver_types.go
+++ b/pkg/apis/v2beta2/receiver_types.go
@@ -48,6 +48,8 @@ type DingTalkReceiver struct {
 	ChatBot *DingTalkChatBot `json:"chatbot,omitempty"`
 	// The conversation which message will send to.
 	Conversation *DingTalkConversation `json:"conversation,omitempty"`
+	// message type: text or markdown
+	MsgType *string `json:"msgType,omitempty"`
 }
 
 type EmailReceiver struct {

--- a/pkg/notify/config/types.go
+++ b/pkg/notify/config/types.go
@@ -122,6 +122,7 @@ type DingTalk struct {
 	ChatBot        *DingTalkChatBot
 	DingTalkConfig *DingTalkConfig
 	Selector       *metav1.LabelSelector
+	MsgType        string
 	*common
 }
 
@@ -146,6 +147,12 @@ func NewDingTalkReceiver(c *Config, dr *v2beta2.DingTalkReceiver) Receiver {
 			configSelector: dr.DingTalkConfigSelector,
 		},
 		Selector: dr.AlertSelector,
+		// default message type : text
+		MsgType: "text",
+	}
+
+	if dr.MsgType != nil {
+		d.MsgType = *dr.MsgType
 	}
 
 	if dr.Conversation != nil {

--- a/pkg/notify/config/types.go
+++ b/pkg/notify/config/types.go
@@ -122,7 +122,7 @@ type DingTalk struct {
 	ChatBot        *DingTalkChatBot
 	DingTalkConfig *DingTalkConfig
 	Selector       *metav1.LabelSelector
-	MsgType        string
+	TmplType       string
 	*common
 }
 
@@ -147,12 +147,10 @@ func NewDingTalkReceiver(c *Config, dr *v2beta2.DingTalkReceiver) Receiver {
 			configSelector: dr.DingTalkConfigSelector,
 		},
 		Selector: dr.AlertSelector,
-		// default message type : text
-		MsgType: "text",
 	}
 
-	if dr.MsgType != nil {
-		d.MsgType = *dr.MsgType
+	if dr.TmplType != nil {
+		d.TmplType = *dr.TmplType
 	}
 
 	if dr.Conversation != nil {

--- a/pkg/notify/notifier/dingtalk/dingtalk.go
+++ b/pkg/notify/notifier/dingtalk/dingtalk.go
@@ -79,6 +79,7 @@ type dingtalkMarkdown struct {
 
 type dingtalkMarkdownMessage struct {
 	Markdown dingtalkMarkdown `yaml:"markdown,omitempty" json:"markdown,omitempty"`
+	ID       string           `yaml:"chatid,omitempty" json:"chatid,omitempty"`
 	Type     string           `yaml:"msgtype,omitempty" json:"msgtype,omitempty"`
 	At       at               `yaml:"at,omitempty" json:"at,omitempty"`
 }
@@ -412,6 +413,7 @@ func (n *Notifier) sendToConversation(ctx context.Context, d *config.DingTalk, d
 					Title: "Alert Notice",
 					Text:  msg,
 				},
+				ID: chatID,
 			}
 			if err := utils.JsonEncode(&buf, dm); err != nil {
 				_ = level.Error(n.logger).Log("msg", "DingTalkNotifier: encode markdown message error", "conversation", chatID, "error", err.Error())


### PR DESCRIPTION
1) support markdown message when use dingtalk chatbot. `kubectl edit nm notification-manager`, config the receivers:
```yaml
dingtalk:
  msgType: markdown
```
2) support @someone when use dingtalk chatbot. message (text or markdown) content need contain phone number like `@131xxxxx899`