### PR TITLE
fix: lack of secret SLACK_SECRET

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -129,9 +129,14 @@ jobs:
           kubectl get pods -n kubesphere-monitoring-system
           echo "-----"
       
-      - name: Deploy the default SlackConfig and global SlackReceiver
+      - name: Deploy the default SlackConfig and global SlackReceiver if the slack secret is set
         run: |
-          cat config/ci/slack-pr.yaml | sed -e 's/SLACK_SECRET/${{ secrets.SLACK_SECRET }}/g' | kubectl apply -f -
+          if [ '${{ secrets.SLACK_SECRET }}' != '' ] ; then
+              cat config/ci/slack-pr.yaml | sed -e 's/SLACK_SECRET/${{ secrets.SLACK_SECRET }}/g' | kubectl apply -f -
+          fi
+          else
+              echo "No Slack secret is set, skipped..."
+          fi
 
       - name: Expose service port as nodeport
         run: |

--- a/config/ci/slack-pr.yaml
+++ b/config/ci/slack-pr.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   slack:
     channels: 
-      - sig-observability
+      - notifications
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
Signed-off-by: zhu733756 <zhu733756@kubesphere.io>

Currently, once the user has not set secret `SLACK_SECRET`, the CI test will be failed.
This pr fixes this case by skipping the notification process to the Slack channel.


See:
-  https://github.com/zhu733756/notification-manager/actions/runs/1371000934