### PR TITLE
Optimize the mechanism of reloading receivers and configs after notif…

### DIFF
--- a/config/bundle.yaml
+++ b/config/bundle.yaml
@@ -7069,6 +7069,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,6 +22,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/config/samples/bundle.yaml
+++ b/config/samples/bundle.yaml
@@ -11,7 +11,7 @@ data:
     {{ end }}
     {{ end }}{{- end }}
 
-    {{ define "nm.default.markdown" }}{{ range . }}### {{ template "nm.default.message" . }}
+    {{ define "nm.default.markdown" }}{{ range .Alerts }}### {{ template "nm.default.message" . }}
     {{ range .Labels.SortedPairs }}- {{ .Name | translate }}: {{ .Value }}
     {{ end }}
     {{ end }}{{- end }}

--- a/config/samples/template.yaml
+++ b/config/samples/template.yaml
@@ -11,7 +11,7 @@ data:
     {{ end }}
     {{ end }}{{- end }}
 
-    {{ define "nm.default.markdown" }}{{ range . }}### {{ template "nm.default.message" . }}
+    {{ define "nm.default.markdown" }}{{ range .Alerts }}### {{ template "nm.default.message" . }}
     {{ range .Labels.SortedPairs }}- {{ .Name | translate }}: {{ .Value }}
     {{ end }}
     {{ end }}{{- end }}

--- a/helm/templates/clusterroles.yaml
+++ b/helm/templates/clusterroles.yaml
@@ -19,6 +19,7 @@ rules:
   - ""
   resources:
   - secrets
+  - configmaps
   verbs:
   - get
   - list

--- a/helm/templates/template.yaml
+++ b/helm/templates/template.yaml
@@ -11,7 +11,7 @@ data:
     {{ "{{ end }}" }}
     {{ "{{ end }}{{- end }}" }}
 
-    {{ "{{ define \"nm.default.markdown\" }}{{ range . }}### {{ template \"nm.default.message\" . }}" }}
+    {{ "{{ define \"nm.default.markdown\" }}{{ range .Alerts }}### {{ template \"nm.default.message\" . }}" }}
     {{ "{{ range .Labels.SortedPairs }}- {{ .Name | translate }}: {{ .Value }}" }}
     {{ "{{ end }}" }}
     {{ "{{ end }}{{- end }}" }}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -411,10 +411,12 @@ func (c *Controller) configChanged(t *task) {
 			if strings.HasSuffix(k, suffix) {
 				oldTenantID = id
 				oldResourceVersion = c.configs[id][k].GetResourceVersion()
+				found = true
 				if t.op == opDel {
 					delete(c.configs[id], k)
+				} else {
+					break
 				}
-				found = true
 			}
 		}
 
@@ -440,7 +442,9 @@ func (c *Controller) configChanged(t *task) {
 	// Delete the old config.
 	if t.op == opUpdate {
 		for k := range c.configs[oldTenantID] {
-			delete(c.configs[oldTenantID], k)
+			if strings.HasSuffix(k, suffix) {
+				delete(c.configs[oldTenantID], k)
+			}
 		}
 	}
 
@@ -484,12 +488,14 @@ func (c *Controller) receiverChanged(t *task) {
 		found := false
 		for k := range c.receivers[id] {
 			if strings.HasSuffix(k, suffix) {
-				if t.op == opDel {
-					delete(c.receivers[id], k)
-				}
 				oldTenantID = id
 				oldResourceVersion = c.receivers[id][k].GetResourceVersion()
 				found = true
+				if t.op == opDel {
+					delete(c.receivers[id], k)
+				} else {
+					break
+				}
 			}
 		}
 
@@ -515,7 +521,9 @@ func (c *Controller) receiverChanged(t *task) {
 	// Delete the old receiver.
 	if t.op == opUpdate {
 		for k := range c.receivers[oldTenantID] {
-			delete(c.receivers[oldTenantID], k)
+			if strings.HasSuffix(k, suffix) {
+				delete(c.receivers[oldTenantID], k)
+			}
 		}
 	}
 

--- a/pkg/internal/common.go
+++ b/pkg/internal/common.go
@@ -21,19 +21,24 @@ type Template struct {
 }
 
 type Common struct {
-	Name           string                `json:"name,omitempty"`
-	Type           string                `json:"type,omitempty"`
-	TenantID       string                `json:"tenantID,omitempty"`
-	Labels         map[string]string     `json:"labels,omitempty"`
-	Enable         *bool                 `json:"enable,omitempty"`
-	AlertSelector  *metav1.LabelSelector `json:"alertSelector,omitempty"`
-	ConfigSelector *metav1.LabelSelector `json:"configSelector,omitempty"`
-	Hash           string                `json:"hash,omitempty"`
-	Template       `json:"template,omitempty"`
+	Name            string                `json:"name,omitempty"`
+	ResourceVersion uint64                `json:"resourceVersion,omitempty"`
+	Type            string                `json:"type,omitempty"`
+	TenantID        string                `json:"tenantID,omitempty"`
+	Labels          map[string]string     `json:"labels,omitempty"`
+	Enable          *bool                 `json:"enable,omitempty"`
+	AlertSelector   *metav1.LabelSelector `json:"alertSelector,omitempty"`
+	ConfigSelector  *metav1.LabelSelector `json:"configSelector,omitempty"`
+	Hash            string                `json:"hash,omitempty"`
+	Template        `json:"template,omitempty"`
 }
 
 func (c *Common) GetName() string {
 	return c.Name
+}
+
+func (c *Common) GetResourceVersion() uint64 {
+	return c.ResourceVersion
 }
 
 func (c *Common) GetTenantID() string {
@@ -83,6 +88,26 @@ func (c *Common) SetHash(h string) {
 
 func (c *Common) GetHash() string {
 	return c.Hash
+}
+
+func (c *Common) Clone() *Common {
+
+	return &Common{
+		Name:           c.Name,
+		Type:           c.Type,
+		TenantID:       c.TenantID,
+		Labels:         c.Labels,
+		Enable:         c.Enable,
+		AlertSelector:  c.AlertSelector,
+		ConfigSelector: c.ConfigSelector,
+		Hash:           c.Hash,
+		Template: Template{
+			TmplName:      c.TmplName,
+			TitleTmplName: c.TitleTmplName,
+			TmplType:      c.TmplType,
+			TmplText:      c.TmplText,
+		},
+	}
 }
 
 func ValidateCredential(c *v2beta2.Credential) error {

--- a/pkg/internal/dingtalk/types.go
+++ b/pkg/internal/dingtalk/types.go
@@ -2,6 +2,7 @@ package dingtalk
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubesphere/notification-manager/pkg/constants"
 	"github.com/kubesphere/notification-manager/pkg/internal"
@@ -50,6 +51,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 			},
 		},
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if dingtalk.Template != nil {
 		r.TmplName = *dingtalk.Template
@@ -125,7 +128,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:  r.Common,
+		Common:  r.Common.Clone(),
 		ChatIDs: r.ChatIDs,
 		ChatBot: r.ChatBot,
 		Config:  r.Config,
@@ -153,6 +156,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 			Labels: obj.Labels,
 		},
 	}
+
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if dingtalk.Conversation != nil {
 		c.AppKey = dingtalk.Conversation.AppKey
@@ -182,7 +187,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common:    c.Common,
+		Common:    c.Common.Clone(),
 		AppKey:    c.AppKey,
 		AppSecret: c.AppSecret,
 	}

--- a/pkg/internal/email/types.go
+++ b/pkg/internal/email/types.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubesphere/notification-manager/pkg/apis/v2beta2"
 	"github.com/kubesphere/notification-manager/pkg/constants"
@@ -38,6 +39,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		},
 		To: e.To,
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if e.Template != nil {
 		r.TmplName = *e.Template
@@ -84,7 +87,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common: r.Common,
+		Common: r.Common.Clone(),
 		To:     r.To,
 		Config: r.Config,
 	}
@@ -121,6 +124,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		AuthSecret:   e.AuthSecret,
 	}
 
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	if e.Hello != nil {
 		c.Hello = *e.Hello
 	}
@@ -151,7 +156,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common:       c.Common,
+		Common:       c.Common.Clone(),
 		From:         c.From,
 		SmartHost:    c.SmartHost,
 		Hello:        c.Hello,

--- a/pkg/internal/feishu/types.go
+++ b/pkg/internal/feishu/types.go
@@ -2,6 +2,7 @@ package feishu
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubesphere/notification-manager/pkg/apis/v2beta2"
 	"github.com/kubesphere/notification-manager/pkg/constants"
@@ -44,6 +45,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		User:       f.User,
 		Department: f.Department,
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if f.Template != nil {
 		r.TmplName = *f.Template
@@ -94,7 +97,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:     r.Common,
+		Common:     r.Common.Clone(),
 		Config:     r.Config,
 		User:       r.User,
 		Department: r.Department,
@@ -124,6 +127,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		AppSecret: f.AppSecret,
 	}
 
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	return c
 }
 
@@ -143,7 +148,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common:    c.Common,
+		Common:    c.Common.Clone(),
 		AppSecret: c.AppSecret,
 		AppID:     c.AppID,
 	}

--- a/pkg/internal/interface.go
+++ b/pkg/internal/interface.go
@@ -5,6 +5,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 type Receiver interface {
 	GetTenantID() string
 	GetName() string
+	GetResourceVersion() uint64
 	Enabled() bool
 	GetType() string
 	GetLabels() map[string]string
@@ -18,6 +19,7 @@ type Receiver interface {
 }
 
 type Config interface {
+	GetResourceVersion() uint64
 	GetLabels() map[string]string
 	GetPriority() int
 	Validate() error

--- a/pkg/internal/pushover/types.go
+++ b/pkg/internal/pushover/types.go
@@ -3,6 +3,7 @@ package pushover
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/modern-go/reflect2"
 
@@ -45,6 +46,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		userKeyRegex: regexp.MustCompile(`^[A-Za-z0-9]{30}$`),
 	}
 
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	if p.Template != nil {
 		r.TmplName = *p.Template
 	}
@@ -85,7 +88,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:       r.Common,
+		Common:       r.Common.Clone(),
 		Profiles:     r.Profiles,
 		userKeyRegex: r.userKeyRegex,
 		Config:       r.Config,
@@ -113,6 +116,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		Token: obj.Spec.Pushover.PushoverTokenSecret,
 	}
 
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	return c
 }
 
@@ -128,7 +133,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common: c.Common,
+		Common: c.Common.Clone(),
 		Token:  c.Token,
 	}
 }

--- a/pkg/internal/slack/types.go
+++ b/pkg/internal/slack/types.go
@@ -2,6 +2,7 @@ package slack
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/modern-go/reflect2"
 
@@ -38,6 +39,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		Channels: s.Channels,
 	}
 
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	if s.Template != nil {
 		r.TmplName = *s.Template
 	}
@@ -71,7 +74,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:   r.Common,
+		Common:   r.Common.Clone(),
 		Channels: r.Channels,
 		Config:   r.Config,
 	}
@@ -97,6 +100,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		Token: obj.Spec.Slack.SlackTokenSecret,
 	}
 
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	return c
 }
 
@@ -112,7 +117,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common: c.Common,
+		Common: c.Common.Clone(),
 		Token:  c.Token,
 	}
 }

--- a/pkg/internal/sms/types.go
+++ b/pkg/internal/sms/types.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/modern-go/reflect2"
 
@@ -38,6 +39,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		},
 		PhoneNumbers: s.PhoneNumbers,
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if s.Template != nil {
 		r.TmplName = *s.Template
@@ -77,7 +80,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:       r.Common,
+		Common:       r.Common.Clone(),
 		PhoneNumbers: r.PhoneNumbers,
 		Config:       r.Config,
 	}
@@ -107,6 +110,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		Providers:       obj.Spec.Sms.Providers,
 		DefaultProvider: obj.Spec.Sms.DefaultProvider,
 	}
+
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	return c
 }
@@ -170,7 +175,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common:          c.Common,
+		Common:          c.Common.Clone(),
 		DefaultProvider: c.DefaultProvider,
 		Providers:       c.Providers,
 	}

--- a/pkg/internal/webhook/types.go
+++ b/pkg/internal/webhook/types.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubesphere/notification-manager/pkg/apis/v2beta2"
 	"github.com/kubesphere/notification-manager/pkg/constants"
@@ -35,6 +36,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		},
 		HttpConfig: w.HTTPConfig,
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if w.Template != nil {
 		r.TmplName = *w.Template
@@ -78,7 +81,7 @@ func (r *Receiver) Validate() error {
 func (r *Receiver) Clone() internal.Receiver {
 
 	return &Receiver{
-		Common:     r.Common,
+		Common:     r.Common.Clone(),
 		URL:        r.URL,
 		HttpConfig: r.HttpConfig,
 		Config:     r.Config,

--- a/pkg/internal/wechat/types.go
+++ b/pkg/internal/wechat/types.go
@@ -2,6 +2,7 @@ package wechat
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubesphere/notification-manager/pkg/apis/v2beta2"
 	"github.com/kubesphere/notification-manager/pkg/constants"
@@ -39,6 +40,8 @@ func NewReceiver(tenantID string, obj *v2beta2.Receiver) internal.Receiver {
 		ToParty: w.ToParty,
 		ToTag:   w.ToTag,
 	}
+
+	r.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
 
 	if w.Template != nil {
 		r.TmplName = *w.Template
@@ -80,13 +83,16 @@ func (r *Receiver) Validate() error {
 
 func (r *Receiver) Clone() internal.Receiver {
 
-	return &Receiver{
-		Common:  r.Common,
-		Config:  r.Config,
-		ToUser:  r.ToUser,
-		ToParty: r.ToParty,
-		ToTag:   r.ToTag,
+	out := &Receiver{
+		Common: r.Common.Clone(),
+		Config: r.Config,
 	}
+
+	out.ToParty = append(out.ToParty, r.ToParty...)
+	out.ToTag = append(out.ToTag, r.ToTag...)
+	out.ToUser = append(out.ToUser, r.ToUser...)
+
+	return out
 }
 
 type Config struct {
@@ -114,6 +120,8 @@ func NewConfig(obj *v2beta2.Config) internal.Config {
 		APISecret: w.WechatApiSecret,
 	}
 
+	c.ResourceVersion, _ = strconv.ParseUint(obj.ResourceVersion, 10, 64)
+
 	return c
 }
 
@@ -137,7 +145,7 @@ func (c *Config) Validate() error {
 func (c *Config) Clone() internal.Config {
 
 	return &Config{
-		Common:    c.Common,
+		Common:    c.Common.Clone(),
 		APISecret: c.APISecret,
 		CorpID:    c.CorpID,
 		APIURL:    c.APIURL,


### PR DESCRIPTION
…ication manager changed


1. A reload operation will be triggered after the notification manager changes, and the receiver and config will be reloaded. Instead of the previous method of triggering events by modifying the annotation, the receiver and config are actively obtained and then pushed to the task queue, which will greatly reduce resource consumption when the number of receivers and configs is large.
2. Not all changes to the notification manager will trigger a reload, `tenantKey` changes will trigger receiver and config reloads, `defaultConfigSelector` changes will trigger config reloads, `globalReceiverSelector` changes will trigger receiver reloads, `tenantReceiverSelector` changes will trigger a receiver and configuration reload.


Signed-off-by: wanjunlei <wanjunlei@kubesphere.io>