### PR TITLE
fix bug regex silence will silence all alert

### DIFF
--- a/apis/v2beta2/common.go
+++ b/apis/v2beta2/common.go
@@ -42,10 +42,13 @@ const (
 )
 
 func (ls *LabelSelector) Matches(label map[string]string) (bool, error) {
+	if label == nil {
+		return false, nil
+	}
+
 	selector := &metav1.LabelSelector{
 		MatchLabels: ls.MatchLabels,
 	}
-
 	for _, requirement := range ls.MatchExpressions {
 		if requirement.Operator != LabelSelectorOpMatch {
 			selector.MatchExpressions = append(selector.MatchExpressions, metav1.LabelSelectorRequirement{
@@ -54,11 +57,9 @@ func (ls *LabelSelector) Matches(label map[string]string) (bool, error) {
 				Values:   requirement.Values,
 			})
 		} else {
-			if v, ok := label[requirement.Key]; ok {
-				match, err := regexp.MatchString(requirement.RegexValue, v)
-				if err != nil || !match {
-					return false, err
-				}
+			match, err := regexp.MatchString(requirement.RegexValue, label[requirement.Key])
+			if !match {
+				return false, err
 			}
 		}
 	}


### PR DESCRIPTION
Fixed bug where regex silence would silence alerts that did not have the match expression key label

For example, all alerts without the label `abc` will be silenced by the following silence, this is not expected behavior.

```
apiVersion: notification.kubesphere.io/v2beta2
kind: Silence
metadata:
  name: silence1
  labels:
    type: global
spec:
  matcher:
    matchExpressions:
      - key: abc
        operator: Match
        regexValue: ".*abc"
  startsAt: "2022-02-24T01:15:20Z"
  schedule: ""
```