### PR TITLE
修改StartsAt字段类型为string，用于接收传输给nm的alert数据结构

### DIFF
--- a/pkg/template/types.go
+++ b/pkg/template/types.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"sort"
-	"time"
 
 	"github.com/kubesphere/notification-manager/pkg/utils"
 
@@ -185,8 +184,8 @@ type Alert struct {
 	Labels      KV     `json:"labels"`
 	Annotations KV     `json:"annotations"`
 
-	StartsAt time.Time `json:"startsAt,omitempty"`
-	EndsAt   time.Time `json:"endsAt,omitempty"`
+	StartsAt string `json:"startsAt,omitempty"`
+	EndsAt   string `json:"endsAt,omitempty"`
 
 	NotifySuccessful bool
 }

--- a/pkg/webhook/v1/handler.go
+++ b/pkg/webhook/v1/handler.go
@@ -161,8 +161,8 @@ func (h *HttpHandler) Verify(w http.ResponseWriter, r *http.Request) {
 			Annotations: template.KV{
 				constants.AlertMessage: "Congratulations, your notification configuration is correct!",
 			},
-			StartsAt: time.Now(),
-			EndsAt:   time.Now(),
+			StartsAt: time.Now().String(),
+			EndsAt:   time.Now().String(),
 		},
 	}
 


### PR DESCRIPTION
[修改StartsAt字段类型为string，用于接收传输给nm的alert数据结构](https://github.com/kubesphere/notification-manager/pull/277)