### PR TITLE
fix(docker): update GOPROXY setting and simplify go mod download command

### DIFF
--- a/cmd/notification-manager/Dockerfile
+++ b/cmd/notification-manager/Dockerfile
@@ -1,7 +1,8 @@
-ARG GOPROXY="https://goproxy.io"
+ARG GOPROXY="https://proxy.golang.org,direct"
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -10,7 +11,7 @@ COPY go.sum go.sum
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN GOPROXY=$GOPROXY go mod download
+RUN go mod download
 
 # Copy the go source
 COPY cmd/notification-manager/main.go main.go

--- a/cmd/operator/Dockerfile
+++ b/cmd/operator/Dockerfile
@@ -1,7 +1,8 @@
-ARG GOPROXY="https://goproxy.io"
+ARG GOPROXY="https://proxy.golang.org,direct"
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.20 AS builder
 ARG GOPROXY
+ENV GOPROXY=${GOPROXY}
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -10,7 +11,7 @@ COPY go.sum go.sum
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN GOPROXY=$GOPROXY go mod download
+RUN go mod download
 
 # Copy the go source
 COPY cmd/operator/main.go main.go
@@ -19,7 +20,7 @@ COPY pkg/ pkg/
 COPY apis/ apis/
 
 # Build
-RUN GOPROXY=$GOPROXY CGO_ENABLED=0 GO111MODULE=on go build -a -o notification-manager-operator main.go
+RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o notification-manager-operator main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
- Change GOPROXY argument value to "https://proxy.golang.org,direct"
- Set GOPROXY as environment variable inside Dockerfiles
- Remove explicit GOPROXY usage in "go mod download" commands
- Use capital AS for Docker build stage aliases
- Simplify build command by removing GOPROXY prefix in operator DockerfileRUN command